### PR TITLE
Add sops 3.7.3 with arm64 bottle

### DIFF
--- a/Formula/sops.rb
+++ b/Formula/sops.rb
@@ -1,0 +1,28 @@
+class Sops < Formula
+  desc "Editor of encrypted files"
+  homepage "https://github.com/mozilla/sops"
+  url "https://github.com/mozilla/sops/archive/v3.7.3.tar.gz"
+  sha256 "0e563f0c01c011ba52dd38602ac3ab0d4378f01edfa83063a00102587410ac38"
+  license "MPL-2.0"
+  head "https://github.com/mozilla/sops.git", branch: "master"
+
+  bottle do
+    root_url "https://github.com/Fullscript/homebrew-tools/releases/download/bottles"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "edadfb5e554fabf348be101e39cc32dbf3a9bf831ebeb27da340bd2d375765c3"
+  end
+
+  depends_on "go" => :build
+  conflicts_with "homebrew/core/sops"
+
+  def install
+    system "go", "build", "-o", bin/"sops", "go.mozilla.org/sops/v3/cmd/sops"
+    pkgshare.install "example.yaml"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/sops --version")
+
+    assert_match "Recovery failed because no master key was able to decrypt the file.",
+      shell_output("#{bin}/sops #{pkgshare}/example.yaml 2>&1", 128)
+  end
+end


### PR DESCRIPTION
Tested locally. Install from source and bottle both work.
Bumping straight to 3.7.3 since 3.7.2 was needed for latest Go support anyway and the goal is getting us back on release stream.

Changelog here: https://github.com/mozilla/sops/releases