### PR TITLE
upgrade vcluster to 0.19.4 with arm bottle

### DIFF
--- a/Formula/vcluster.rb
+++ b/Formula/vcluster.rb
@@ -2,9 +2,10 @@ class Vcluster < Formula
   desc "Creates fully functional virtual k8s cluster inside host k8s cluster's namespace"
   homepage "https://www.vcluster.com"
   url "https://github.com/loft-sh/vcluster.git",
-      tag:      "v0.14.2",
-      revision: "0dac15bff8ee6b4048b1f2c44a97eb95820d3ec2"
+      tag:      "v0.19.4",
+      revision: "416b9919b7cda19e6011bf16f964fc149595c0e4"
   license "Apache-2.0"
+  head "https://github.com/loft-sh/vcluster.git", branch: "main"
 
   depends_on "go" => :build
   depends_on "helm"
@@ -14,8 +15,8 @@ class Vcluster < Formula
 
   bottle do
     root_url "https://github.com/Fullscript/homebrew-tools/releases/download/bottles"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "72468f665b007d39c6d040ecfb44c2c500dc0b249f8dee8e51ace1fb1aad3f91"
-    sha256 cellar: :any_skip_relocation, ventura: "5ae199dba373d25b2b3d0420af2ea5884b9df33f1f8175719d2ef46d4009df97"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma: "a658640de9f608dedf6ada0236a3c1974bf25a849645cd1ffde27614c57d91ae"
+    # sha256 cellar: :any_skip_relocation, ventura: "5ae199dba373d25b2b3d0420af2ea5884b9df33f1f8175719d2ef46d4009df97"
   end
 
   def install
@@ -27,6 +28,7 @@ class Vcluster < Formula
     ]
     system "go", "generate", "./..."
     system "go", "build", "-mod", "vendor", *std_go_args(ldflags: ldflags), "./cmd/vclusterctl/main.go"
+    generate_completions_from_executable(bin/"vcluster", "completion")
   end
 
   test do
@@ -38,6 +40,6 @@ class Vcluster < Formula
                     "try setting KUBERNETES_MASTER environment variable), " \
                     "please make sure you have access to a kubernetes cluster and the command " \
                     "`kubectl get namespaces` is working"
-    assert_match create_output, shell_output("#{bin}/vcluster create vcluster -n vcluster --create-namespace", 1)
+    assert_match create_output, shell_output("#{bin}/vcluster create vcluster -n vcluster --create-namespace 2>&1", 1)
   end
 end


### PR DESCRIPTION
## Development:

In order to fix the Wiz vulnerability issue , we need to upgrade vcluster bottle used by our developers. I have built and uploaded the bottle for arm arch users, @codrmonkey can you please build one for amd? Thanks.

This is the vcluster release that we are building upon it. https://github.com/loft-sh/vcluster/releases/tag/v0.19.4

The official vcluster formula : https://github.com/Homebrew/homebrew-core/blob/master/Formula/v/vcluster.rb

Our internal doc for bottling instruction: https://docs.google.com/document/d/1dsTSkUqrDAqpajDkxz_wH1DWioWq8AtKlj9yYbqbU1k/edit

## Testing:
- `cd $(brew --repo fullscript/homebrew-tools)`
- `git checkout upgrade-vcluster`
- `brew install fullscript/homebrew-tools/vcluster` to get 0.19.4 installed.

