### PR TITLE
Upgrade Opus model to Claude Opus 4.7

### DIFF
--- a/Casks/fullscript-claude-code.rb
+++ b/Casks/fullscript-claude-code.rb
@@ -10,7 +10,7 @@ class FullscriptClaudeCode
   AWS_BIN = "#{HOMEBREW_PREFIX}/bin/aws"
   MIN_AWS_VERSION = "2.27.63"
   INFERENCE_PROFILES = {
-    "opus-4-6" => "global.anthropic.claude-opus-4-6-v1",
+    "opus-4-7" => "global.anthropic.claude-opus-4-7",
     "sonnet-4-6" => "global.anthropic.claude-sonnet-4-6",
     "haiku-4-5" => "global.anthropic.claude-haiku-4-5-20251001-v1:0",
   }.freeze
@@ -209,10 +209,10 @@ class FullscriptClaudeCode
       export AWS_REGION=#{REGION}
 
       # Primary model (used by default)
-      export ANTHROPIC_MODEL="#{arns["opus-4-6"]}"
+      export ANTHROPIC_MODEL="#{arns["opus-4-7"]}"
 
       # Default model aliases (maps opus/sonnet/haiku commands to inference profiles)
-      export ANTHROPIC_DEFAULT_OPUS_MODEL="#{arns["opus-4-6"]}"
+      export ANTHROPIC_DEFAULT_OPUS_MODEL="#{arns["opus-4-7"]}"
       export ANTHROPIC_DEFAULT_SONNET_MODEL="#{arns["sonnet-4-6"]}"
       export ANTHROPIC_DEFAULT_HAIKU_MODEL="#{arns["haiku-4-5"]}"
 
@@ -296,7 +296,7 @@ class FullscriptClaudeCode
 end
 
 cask "fullscript-claude-code" do
-  version "1.2.0"
+  version "1.3.0"
   sha256 :no_check
 
   url "file:///dev/null"


### PR DESCRIPTION
## Summary
- Upgrade the default Opus inference profile from `claude-opus-4-6-v1` to `claude-opus-4-7`
- Updates `ANTHROPIC_MODEL` and `ANTHROPIC_DEFAULT_OPUS_MODEL` env vars to use the new profile
- Stale `opus-4-6` profiles will be automatically cleaned up on next install

## Test plan
- [ ] Run `brew reinstall fullscript-claude-code` and verify the new `opus-4-7` inference profile is created
- [ ] Verify old `opus-4-6` inference profile is deleted during cleanup
- [ ] Confirm `env.sh` references the new `opus-4-7` profile ARN

🤖 Generated with [Claude Code](https://claude.com/claude-code)